### PR TITLE
feat: one issue = one PR (accumulate commits on issue branch)

### DIFF
--- a/.whitesmith-commit-msg
+++ b/.whitesmith-commit-msg
@@ -1,0 +1,17 @@
+feat: one issue = one PR (accumulate commits on issue branch)
+
+Changes:
+- Implement phase now uses issue/<number> branch instead of task/<id>
+- Each task implementation adds one commit to the issue branch
+- Reconcile phase creates PR when all tasks are complete
+- No more useless intermediate PRs for individual tasks
+
+Benefits:
+- Error recovery: issue branch persists across runs, can resume from last task
+- Cleaner review: one coherent PR per issue instead of N task PRs
+- Less CI overhead: 1 PR run vs N PR runs
+- Git history shows task progression via commits
+
+Fixes issue described in PR #17 comment where autoWork crashes mid-way
+would lose task files and prevent resumption. Now branch persists with
+all task files, enabling easy recovery.

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -10,9 +10,13 @@ import {buildInvestigatePrompt, buildImplementPrompt} from './prompts.js';
  * Main orchestrator for whitesmith.
  *
  * The loop:
- * 1. Reconcile — check if any issues with tasks-accepted have all tasks done
+ * 1. Reconcile — issues with tasks-accepted where all tasks are done: create PR
  * 2. Investigate — pick an unlabeled issue, generate tasks
- * 3. Implement — pick an available task, implement it
+ * 3. Implement — pick an available task, implement it on issue branch
+ *
+ * Branch strategy:
+ * - Investigate: `investigate/<issue-number>` → PR for task review
+ * - Implement: `issue/<issue-number>` → accumulates commits, one PR when all tasks done
  */
 export class Orchestrator {
 	private config: DevPulseConfig;
@@ -152,7 +156,7 @@ export class Orchestrator {
 					continue;
 				}
 
-				const branch = `task/${task.id}`;
+				const branch = `issue/${issue.number}`;
 				const branchExists = await this.issues.remoteBranchExists(branch);
 				if (branchExists) {
 					// Branch exists — check if it already has a PR
@@ -173,21 +177,53 @@ export class Orchestrator {
 	}
 
 	/**
-	 * Phase 1: Reconcile — mark issue as completed, close it
+	 * Phase 1: Reconcile — all tasks done, create PR and mark issue as completed
 	 */
 	private async reconcile(issue: Issue): Promise<void> {
 		console.log(`Reconciling issue #${issue.number}: ${issue.title}`);
-		console.log('All tasks completed. Marking issue as done.');
+		console.log('All tasks completed. Creating PR.');
 
-		await this.issues.addLabel(issue.number, LABELS.COMPLETED);
-		await this.issues.removeLabel(issue.number, LABELS.TASKS_ACCEPTED);
-		await this.issues.comment(
-			issue.number,
-			`✅ All tasks for this issue have been implemented and merged. Closing.`,
-		);
-		await this.issues.closeIssue(issue.number);
+		const branch = `issue/${issue.number}`;
 
-		console.log(`Issue #${issue.number} closed.`);
+		if (this.config.noPush) {
+			console.log(`Branch '${branch}' ready (--no-push mode)`);
+			await this.issues.addLabel(issue.number, LABELS.COMPLETED);
+			await this.issues.removeLabel(issue.number, LABELS.TASKS_ACCEPTED);
+			return;
+		}
+
+		try {
+			// Check if PR already exists
+			const existingPR = await this.issues.getPRForBranch(branch);
+			let prUrl: string;
+
+			if (existingPR && existingPR.state === 'open') {
+				prUrl = existingPR.url;
+				console.log(`PR already exists: ${prUrl}`);
+			} else {
+				// Create PR summarizing all completed tasks
+				const prUrl = await this.issues.createPR({
+					head: branch,
+					base: 'main',
+					title: `feat(#${issue.number}): ${issue.title}`,
+					body: `## Implementation of #${issue.number}\n\n${issue.title}\n\nAll tasks have been implemented and tested.\n\n---\n*Implemented by whitesmith*\n\nCloses #${issue.number}`,
+				});
+				console.log(`PR created: ${prUrl}`);
+			}
+
+			await this.issues.addLabel(issue.number, LABELS.COMPLETED);
+			await this.issues.removeLabel(issue.number, LABELS.TASKS_ACCEPTED);
+			await this.issues.comment(
+				issue.number,
+				`✅ All tasks for this issue have been implemented. PR: ${prUrl}`,
+			);
+		} catch (error) {
+			console.error('Failed to create PR:', error instanceof Error ? error.message : error);
+			// Don't mark as completed if PR creation failed
+			return;
+		}
+
+		console.log(`Issue #${issue.number} marked as completed.`);
 	}
 
 	/**
@@ -303,13 +339,13 @@ export class Orchestrator {
 	}
 
 	/**
-	 * Phase 3: Implement — implement a task and create a PR
+	 * Phase 3: Implement — implement a task on the issue branch
 	 */
 	private async implement(task: Task, issue: Issue): Promise<void> {
 		console.log(`Implementing task ${task.id}: ${task.title}`);
 		console.log(`For issue #${issue.number}: ${issue.title}`);
 
-		const branch = `task/${task.id}`;
+		const branch = `issue/${issue.number}`;
 
 		try {
 			// Check if a previous attempt already completed work on this branch.
@@ -358,7 +394,7 @@ export class Orchestrator {
 			// Verify we're still on the right branch
 			await this.git.verifyBranch(branch);
 
-			// Ensure changes are committed
+			// Ensure changes are committed (one commit per task)
 			await this.git.commitAll(`feat(#${issue.number}): ${task.title}`);
 
 			if (this.config.noPush) {
@@ -366,24 +402,7 @@ export class Orchestrator {
 			} else {
 				// Force push since the branch may exist from a previous failed attempt
 				await this.git.forcePush(branch);
-
-				// Check if a PR already exists for this branch
-				const existingPR = await this.issues.getPRForBranch(branch);
-				let prUrl: string;
-
-				if (existingPR && existingPR.state === 'open') {
-					prUrl = existingPR.url;
-					console.log(`PR already exists: ${prUrl}`);
-				} else {
-					prUrl = await this.issues.createPR({
-						head: branch,
-						base: 'main',
-						title: `feat(#${issue.number}): ${task.title}`,
-						body: `## Task: ${task.title}\n\nImplements task \`${task.id}\` from issue #${issue.number}.\n\n### From the task spec:\n\n${task.content}\n\n---\n*Implemented by whitesmith*\n\nCloses #${issue.number} (if all tasks are complete)`,
-					});
-				}
-
-				console.log(`PR created: ${prUrl}`);
+				console.log(`Pushed to branch '${branch}'`);
 			}
 		} catch (error) {
 			console.error('Implementation failed:', error instanceof Error ? error.message : error);


### PR DESCRIPTION
## Problem

Currently, whitesmith creates **one PR per task**, which leads to:

1. **Useless intermediate PRs** - Individual tasks are often meaningless alone, requiring multiple PRs to create a coherent change
2. **Error recovery issues** - If `autoWork()` crashes mid-way (task 1 succeeds, task 2 fails), task files aren't on `main` and normal `implement` flow can't resume (see [PR #17 comment](https://github.com/wighawag/whitesmith/pull/17#issuecomment-4180375450))
3. **CI overhead** - N tasks = N PR runs instead of 1

## Solution

**One issue = one PR** with accumulated commits:

### Current Flow
```
Task 1 → branch task/001 → PR #101 (useless alone)
Task 2 → branch task/002 → PR #102 (useless alone)
Task 3 → branch task/003 → PR #103 (finally useful)
```

### New Flow
```
Task 1 → commit abc on branch issue/42
Task 2 → commit def on branch issue/42
Task 3 → commit ghi on branch issue/42
       ↓
    PR #101 (all 3 commits, coherent change)
```

## Changes

### Branch Strategy
- **Investigate**: `investigate/<issue-number>` → PR for task review (unchanged)
- **Implement**: `issue/<issue-number>` → accumulates commits, one PR when all tasks done (changed)

### Key Modifications

1. **`orchestrator.ts` - `findAvailableTask()`**
   - Branch naming: `issue/<number>` instead of `task/<id>`

2. **`orchestrator.ts` - `implement()`**
   - Pushes to `issue/<number>` branch (accumulates commits)
   - **Removed**: PR creation (moved to reconcile)

3. **`orchestrator.ts` - `reconcile()`**
   - **Added**: PR creation when all tasks complete
   - PR summarizes all completed tasks

## Benefits

✅ **Error Recovery** - Issue branch persists across runs. If agent crashes at task 2, branch still has all task files. Next run resumes from last completed task.

✅ **Cleaner Review** - One coherent PR per issue instead of N fragmented task PRs

✅ **Less CI Overhead** - 1 PR run vs N PR runs

✅ **Git History** - Commits show task progression within the issue

✅ **No Useless PRs** - No more merging meaningless intermediate PRs

## Testing

The change maintains backward compatibility with the task file structure (`tasks/<issue>/<seq>-<slug>.md`) which was already in place.

---

*This addresses the error recovery gap described in PR #17*